### PR TITLE
Remove synchronous XMLHttpRequest flag

### DIFF
--- a/static/js/tipuesearch.js
+++ b/static/js/tipuesearch.js
@@ -32,9 +32,6 @@ http://www.tipue.com/search
                var tipuesearch_in = {
                     pages: []
                };
-               $.ajaxSetup({
-                    async: false
-               });
 
                if (set.mode == 'live')
                {

--- a/templates/analytics.html
+++ b/templates/analytics.html
@@ -11,7 +11,7 @@ var u=(("https:" == document.location.protocol) ? "https://{{ PIWIK_URL }}/" : "
  _paq.push(['setTrackerUrl', u+'piwik.php']);
  _paq.push(['trackPageView']);
  _paq.push(['enableLinkTracking']);
- var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0]; g.type='text/javascript'; g.defer=true; g.async=true; g.src=u+'piwik.js';
+ var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0]; g.type='text/javascript'; g.defer=true;  g.src=u+'piwik.js';
  s.parentNode.insertBefore(g,s); })();
 </script>
 <!-- End Piwik Code -->

--- a/templates/article.html
+++ b/templates/article.html
@@ -85,7 +85,7 @@
 
     /* * * DON'T EDIT BELOW THIS LINE * * */
     (function() {
-     var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+     var dsq = document.createElement('script'); dsq.type = 'text/javascript'; 
      dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
      (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
      })();

--- a/templates/disqus_count.html
+++ b/templates/disqus_count.html
@@ -4,7 +4,7 @@ var disqus_shortname = '{{ DISQUS_SITENAME }}'; // required: replace example wit
 
 /* * * DON'T EDIT BELOW THIS LINE * * */
 (function () {
- var s = document.createElement('script'); s.async = true;
+ var s = document.createElement('script');
  s.type = 'text/javascript';
  s.src = '//' + disqus_shortname + '.disqus.com/count.js';
  (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);


### PR DESCRIPTION
When "async: false" is set, the following error shows in the browser console (Firefox):
`Synchronous XMLHttpRequest on the main thread is deprecated because of its detrimental effects to the end user's experience.`

As "async: true" is the default, I also removed instances where async was explicitly set to true.
