### PR TITLE
lowercase 'PAGES' variable in template

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -104,7 +104,7 @@
                     {% if DISPLAY_PAGES_ON_MENU != False %}
                     <li class="uk-nav-header">Pages</li>
 
-                    {% for p in PAGES %}
+                    {% for p in pages %}
                     <li {% if p == page %}class="uk-active"{% endif %}>
                         <a href="{{ SITEURL }}/{{ p.url }}">{{ p.title }}</a>
                     </li>
@@ -179,7 +179,7 @@
             {% endfor %}
             {% if DISPLAY_PAGES_ON_MENU != False %}
             <li class="uk-nav-header">Pages</li>
-            {% for p in PAGES %}
+            {% for p in pages %}
             <li {% if p == page %}class="uk-active"{% endif %}>
                 <a href="{{ SITEURL }}/{{ p.url }}">{{ p.title }}</a>
             </li>


### PR DESCRIPTION
Pages index/links were not appearing in the menu for whatever the value for {% if DISPLAY_PAGES_ON_MENU != False %} when the for loop was executed -> {% for p in PAGES %} | for a reason lowercase the variable name PAGES to pages works fine.