### PR TITLE
change http to https for disqus

### DIFF
--- a/templates/article.html
+++ b/templates/article.html
@@ -91,7 +91,7 @@
      })();
     </script>
     <noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
-    <a href="http://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>
+    <a href="https://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>
     {% endif %}
 
 </div>


### PR DESCRIPTION
Changed to secure protocol for the call to http://disqus.com (https)