### PR TITLE
removing google plus

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The theme is suited for a single author blog without tag pages nor
 blogroll. Feeds are provided via ATOM.
 
 
-Screenshots 
+Screenshots
 --------------
 
 Here is how the home page look like
@@ -17,7 +17,7 @@ This is the article page
 
 ![mg article page screenshot](https://raw.githubusercontent.com/lucachr/pelican-mg/master/article-screenshot.png)
 
-The home page on a smartphone 
+The home page on a smartphone
 
 ![mg home page smartphone top screenshot](https://github.com/lucachr/pelican-mg/blob/master/home-page-smartphone-top.png)
 ![mg home page smartphone bottom screenshot](https://github.com/lucachr/pelican-mg/blob/master/home-page-smartphone-bottom.png)
@@ -88,9 +88,9 @@ The MIME type of your favicon, this is needed for Disqus forum favicon.
 A custom footer notice.
 
 **META_IMAGE**  
-The absolute URL of a custom image for the `og:image` meta property, Twitter 
-summary card, and `image` meta property of Schema.org. This image is used in 
-every page of the blog. Articles and pages can override the default 
+The absolute URL of a custom image for the `og:image` meta property, Twitter
+summary card, and `image` meta property of Schema.org. This image is used in
+every page of the blog. Articles and pages can override the default
 **META_IMAGE** by setting the "image" metadata in the relative file.  
 
 **META_IMAGE_TYPE**  
@@ -107,12 +107,11 @@ Enable share buttons, boolean.
 
 **SOCIAL**  
 A list of tuples (icon, URL). The icons are from [Font Awesome]
-(http://fortawesome.github.io/Font-Awesome/). The suffix "-square" is removed 
+(http://fortawesome.github.io/Font-Awesome/). The suffix "-square" is removed
 in the footer icons of the small screen layout.   
 e.g.   
 ```python
     SOCIAL = (('twitter', 'https://twitter.com/luca_chr'),
-              ('google-plus-square', 'https://plus.google.com/117284397605208270870'),
               ('github', 'https://github.com/lucachr'),
               ('envelope', 'mailto:luca92web@gmail.com'),)
 ```
@@ -150,7 +149,6 @@ This is the settings file for Dev's Bytes.
 
     # Social widget
     SOCIAL = (('twitter', 'https://twitter.com/luca_chr'),
-              ('google-plus-square', 'https://plus.google.com/+LucaChiricozzi'),
               ('github', 'https://github.com/lucachr'),
               ('envelope', 'mailto:luca92web@gmail.com'),)
 

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -3,7 +3,6 @@ $accentGreen: #28D1B2;
 $feedOrange: #FF6600;
 $twitterBlue: #00B0ED;
 $facebookBlue: #3B5999;
-$googleRed: #D34836;
 $githubBlack: #333;
 $mailBlue: #059;
 $textGrey: #444;
@@ -49,10 +48,6 @@ a {
 
 .uk-icon-facebook, .uk-icon-facebook-square {
     color: $facebookBlue;
-}
-
-.uk-icon-google-plus, .uk-icon-google-plus-square {
-    color: $googleRed;
 }
 
 .uk-icon-github {
@@ -217,10 +212,6 @@ a {
 
     .uk-icon-facebook {
         background-color: $facebookBlue;
-    }
-
-    .uk-icon-google-plus {
-        background-color: $googleRed;
     }
 
     .uk-icon-github {

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -22,9 +22,6 @@ a {
 .uk-icon-facebook, .uk-icon-facebook-square {
   color: #3B5999; }
 
-.uk-icon-google-plus, .uk-icon-google-plus-square {
-  color: #D34836; }
-
 .uk-icon-github {
   color: #333; }
 
@@ -133,8 +130,6 @@ a {
   background-color: #00B0ED; }
 .mg-icons-small .uk-icon-facebook {
   background-color: #3B5999; }
-.mg-icons-small .uk-icon-google-plus {
-  background-color: #D34836; }
 .mg-icons-small .uk-icon-github {
   background-color: #333; }
 .mg-icons-small .uk-icon-envelope {
@@ -149,4 +144,3 @@ a {
   background: #ccc;
   color: #000;
   padding: 0.2em 0; }
-

--- a/templates/article.html
+++ b/templates/article.html
@@ -51,9 +51,6 @@
             <li>
             <a href="https://twitter.com/intent/tweet?text={{ article.title|striptags|urlencode }}&url={{ SITEURL }}/{{ article.url }}&via={{ TWITTER_USERNAME }}" onclick="javascript:window.open(this.href,'', 'menubar=no,toolbar=no,resizable=yes,scrollbars=yes,height=600,width=600');return false;" class="uk-button" target="_blank"><i class="uk-icon-twitter"></i> Tweet</a>
             </li>
-            <li>
-            <a href="https://plus.google.com/share?url={{ SITEURL }}/{{ article.url }}" onclick="javascript:window.open(this.href,'', 'menubar=no,toolbar=no,resizable=yes,scrollbars=yes,height=600,width=600');return false;" target="_blank" class="uk-button"><i class="uk-icon-google-plus-square"></i> Share</a>
-            </li>
         </ul>
     </div>
     {% endif %}
@@ -69,7 +66,6 @@
         {% if SHARE %}
         <a href="https://www.facebook.com/sharer/sharer.php?u={{ SITEURL }}/{{ article.url }}" onclick="javascript:window.open(this.href,'', 'menubar=no,toolbar=no,resizable=yes,scrollbars=yes,height=300,width=600');return false;" taget="_blank" class="uk-button uk-visible-small"><i class="uk-icon-facebook-square"></i> Share</a>
         <a href="https://twitter.com/intent/tweet?text={{ article.title|striptags|urlencode }}&url={{ SITEURL }}/{{ article.url }}&via={{ TWITTER_USERNAME }}" onclick="javascript:window.open(this.href,'', 'menubar=no,toolbar=no,resizable=yes,scrollbars=yes,height=600,width=600');return false;" class="uk-button uk-visible-small" target="_blank"><i class="uk-icon-twitter"></i> Tweet</a>
-        <a href="https://plus.google.com/share?url={{ SITEURL }}/{{ article.url }}" onclick="javascript:window.open(this.href,'', 'menubar=no,toolbar=no,resizable=yes,scrollbars=yes,height=600,width=600');return false;" target="_blank" class="uk-button uk-visible-small"><i class="uk-icon-google-plus-square"></i> Share</a>
         {% endif %}
 
         <p class="uk-article-lead" itemprop="description">{{ article.summary|striptags }}</p>


### PR DESCRIPTION
As google plus will [shut down](https://www.blog.google/technology/safety-security/project-strobe/) it's public service soon, I went ahead and removed it from the sharing feature. No need to merge it yet, but would probably be good for longevity!