### PR TITLE
Fixed issue with search not working from category page

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -90,7 +90,7 @@
             {% if not DISABLE_SEARCH %}
             <div class="uk-panel uk-panel-box">
                 <form class="uk-search" action="search.html" data-uk-search>
-                    <input class="uk-search-field tipue_search" type="search" name="q" id="tipue_search_input" autocomplete="off" placeholder="Search...">
+                    <input class="uk-search-field tipue_search" type="{{ SITEURL }}/search" name="q" id="tipue_search_input" autocomplete="off" placeholder="Search...">
                 </form>
             </div>
             {% endif %}
@@ -167,7 +167,7 @@
     <div class="uk-offcanvas-bar">
 
         {% if not DISABLE_SEARCH %}
-        <form class="uk-search" action="search.html" data-uk-search>
+        <form class="uk-search" action="{{ SITEURL }}/search.html" data-uk-search>
             <input class="uk-search-field" type="search" name="q" id="tipue_search_input" autocomplete="off" placeholder="Search...">
         </form>
         {% endif %}


### PR DESCRIPTION
I noticed that when trying to search for a term from any of the category pages that it would try and redirect the search to `/category/search.html` and I was getting a 404 error because that doesn't exist. I noticed in the `base.html` template that the action in the search form was just set to "search.html" so I changed it to:

`<form class="uk-search" action="{{ SITEURL }}/search.html" data-uk-search>`

I did that for both instances of the search form and my issue went away.